### PR TITLE
Add IndexedDB storage for saved searches (resolves #4)

### DIFF
--- a/src/_data/filters.js
+++ b/src/_data/filters.js
@@ -1,0 +1,4 @@
+module.exports = {
+	animals: ['cat', 'dog', 'rabbit', 'rat'],
+	colors: ['white', 'black', 'brown', 'silver']
+};

--- a/src/_data/navigation.js
+++ b/src/_data/navigation.js
@@ -1,0 +1,10 @@
+module.exports = [
+	{
+		url: '/',
+		text: 'Home'
+	},
+	{
+		url: '/search/',
+		text: 'Search'
+	}
+];

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -1,6 +1,3 @@
----
-title: PWA Experiments
----
 <!doctype html>
 <html lang="en">
 	<head>
@@ -8,37 +5,36 @@ title: PWA Experiments
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-css-reset/dist/reset.min.css"/>
 		<link rel="stylesheet" href="/css/pwa.css"/>
-		<title>{{ title }}</title>
+		<title>{{ title }} | PWA Experiments</title>
 	</head>
 	<body>
 		{% if offline %}
-			<div class="offline-tag">OFFLINE MODE</div>
+			<div class="offline-tag">Offline Mode</div>
 		{% endif %}
 		<header>
 			<h1>{{ title }}</h1>
+			<nav>
+				<ul class="menu">
+					{% for item in navigation %}
+						{% set currentAttribute = '' %}
+						{% if page.url == item.url %}
+							{% set currentAttribute = ' aria-current="page"' %}
+						{% endif %}
+
+						<li>
+							<a href="{{ item.url }}"{{ currentAttribute | safe }}>{{ item.text }}</a>
+						</li>
+					{% endfor %}
+				</ul>
+			</nav>
 		</header>
 		<main>
 			<article>
-				{{ content | safe }}
+				{% block content %}{% endblock %}
 			</article>
 		</main>
 		<footer>
-			<div id="notice" aria-live="polite"></div>
-			<form id="settings">
-				<fieldset>
-					<legend>Settings</legend>
-					<label for="lang">
-						Site Language
-						<select id="lang" hidden{% if offline %} disabled{% endif %}>
-							{% for code, label in languages %}
-								<option value="{{ code }}">{{ label }}</option>
-							{% endfor %}
-						</select>
-					</label>
-
-					<input id="submit" type="submit" value="Save" {% if offline %}disabled {% endif %}/>
-				</fieldset>
-			</form>
+			{% include 'partials/settings.njk' %}
 		</footer>
 	</body>
 	<script src="/js/pwa.js"></script>

--- a/src/_includes/layouts/page.njk
+++ b/src/_includes/layouts/page.njk
@@ -1,0 +1,5 @@
+{% extends 'layouts/base.njk' %}
+
+{% block content %}
+	{{ content | safe }}
+{% endblock %}

--- a/src/_includes/layouts/search.njk
+++ b/src/_includes/layouts/search.njk
@@ -1,0 +1,29 @@
+{% extends 'layouts/base.njk' %}
+
+{% block content %}
+	{{ content | safe }}
+	<form>
+		<label for="search">
+			Search
+		</label>
+		<input id="search" type="search" name="s"/>
+		{% for taxonomy, terms in filters %}
+			<fieldset>
+				<legend>{{ taxonomy | capitalize }}</legend>
+				<ul class="{{ taxonomy }}">
+					{% for term in terms %}
+						<li>
+							<input id="{{ term }}" name="{{ taxonomy }}[{{ term }}]" type="checkbox" value="{{ term }}"/>
+							<label for="{{ term }}">{{ term | capitalize }}</label>
+						</li>
+					{% endfor %}
+				</ul>
+			</fieldset>
+		{% endfor %}
+		<input id="submit" type="submit" value="Search" {% if offline %}disabled {% endif %}/>
+	</form>
+
+	<div id="searches">
+		<h2>Saved Searches</h2>
+	</div>
+{% endblock %}

--- a/src/_includes/layouts/search.njk
+++ b/src/_includes/layouts/search.njk
@@ -2,28 +2,29 @@
 
 {% block content %}
 	{{ content | safe }}
-	<form>
+	<form id="search-form" action="/">
 		<label for="search">
 			Search
 		</label>
-		<input id="search" type="search" name="s"/>
+		<input id="search-field" type="search" name="s"/>
 		{% for taxonomy, terms in filters %}
 			<fieldset>
 				<legend>{{ taxonomy | capitalize }}</legend>
 				<ul class="{{ taxonomy }}">
 					{% for term in terms %}
 						<li>
-							<input id="{{ term }}" name="{{ taxonomy }}[{{ term }}]" type="checkbox" value="{{ term }}"/>
+							<input id="{{ term }}" name="{{ taxonomy }}" type="checkbox" value="{{ term }}"/>
 							<label for="{{ term }}">{{ term | capitalize }}</label>
 						</li>
 					{% endfor %}
 				</ul>
 			</fieldset>
 		{% endfor %}
-		<input id="submit" type="submit" value="Search" {% if offline %}disabled {% endif %}/>
+		<input id="search-submit" type="submit" value="Search" {% if offline %}disabled {% endif %}/>
 	</form>
 
 	<div id="searches">
 		<h2>Saved Searches</h2>
+		<ul id="saved-searches" class="saved-searches"></ul>
 	</div>
 {% endblock %}

--- a/src/_includes/partials/settings.njk
+++ b/src/_includes/partials/settings.njk
@@ -1,0 +1,16 @@
+<div id="notice" aria-live="polite"></div>
+<form id="settings">
+	<fieldset>
+		<legend>Settings</legend>
+		<label for="lang">
+			Site Language
+		</label>
+		<select id="lang" hidden{% if offline %} disabled{% endif %}>
+			{% for code, label in languages %}
+				<option value="{{ code }}">{{ label }}</option>
+			{% endfor %}
+		</select>
+
+		<input id="submit" type="submit" value="Save" {% if offline %}disabled {% endif %}/>
+	</fieldset>
+</form>

--- a/src/css/pwa.css
+++ b/src/css/pwa.css
@@ -25,6 +25,59 @@ header {
 	padding-top: 1rem;
 }
 
+nav {
+	margin-top: 1rem;
+}
+
+nav li {
+	display: inline-block;
+	margin-right: 0.5rem;
+}
+
+nav a,
+nav a:visited {
+	--fg: black;
+	--bg: white;
+	--border: black;
+
+	background-color: var(--bg);
+	border: solid 2px var(--border);
+	color: var(--fg);
+	display: block;
+	padding: 0.25rem 1rem;
+	text-decoration: none;
+}
+
+nav a:hover {
+	--fg: white;
+	--bg: black;
+}
+
+nav a:focus {
+	box-shadow: inset 0 0 0 2px var(--fg);
+}
+
+nav a:active {
+	--fg: white;
+	--bg: black;
+
+	box-shadow: inset 0 0 0 2px var(--fg);
+}
+
+nav a[aria-current] {
+	--fg: white;
+	--bg: black;
+}
+
+nav a[aria-current]:hover,
+nav a[aria-current]:focus {
+	box-shadow: inset 0 0 0 2px var(--fg);
+}
+
+nav li:first-child a {
+	margin-left: 0;
+}
+
 fieldset {
 	border: solid 2px black;
 	padding: 0.5rem 1rem 1rem;
@@ -35,13 +88,28 @@ select {
 	display: block;
 	margin-top: 0.5rem;
 }
+[type="checkbox"] {
+	display: inline-block;
+}
+
+form * + * {
+	margin-top: 1.5rem;
+}
 
 fieldset * + * {
 	margin-top: 1.5rem;
 }
 
-fieldset legend + * {
+legend + * {
 	margin-top: 1rem;
+}
+
+label + * {
+	margin-top: 0.5rem;
+}
+
+fieldset li + li {
+	margin-top: 0;
 }
 
 [type="submit"] {
@@ -141,6 +209,7 @@ fieldset legend + * {
 	color: #fff;
 	display: block;
 	text-align: center;
+	text-transform: uppercase;
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/css/pwa.css
+++ b/src/css/pwa.css
@@ -112,6 +112,7 @@ fieldset li + li {
 	margin-top: 0;
 }
 
+button,
 [type="submit"] {
 	--fg: black;
 	--bg: white;
@@ -126,19 +127,27 @@ fieldset li + li {
 	padding: 0.25rem 1rem;
 }
 
+* + button {
+	margin-top: 1rem;
+}
+
+button::-moz-focus-inner,
 [type="submit"]::-moz-focus-inner {
 	border: 0;
 }
 
+button:hover,
 [type="submit"]:hover {
 	--fg: white;
 	--bg: black;
 }
 
+button:focus,
 [type="submit"]:focus {
 	box-shadow: inset 0 0 0 2px var(--fg);
 }
 
+button:active,
 [type="submit"]:active {
 	--fg: white;
 	--bg: black;
@@ -146,6 +155,7 @@ fieldset li + li {
 	box-shadow: inset 0 0 0 2px var(--fg);
 }
 
+button[disabled],
 [type="submit"][disabled] {
 	--fg: #555;
 	--border: #555;
@@ -153,6 +163,7 @@ fieldset li + li {
 	cursor: auto;
 }
 
+button[disabled]:hover,
 [type="submit"][disabled]:hover {
 	--fg: #555;
 	--bg: white;
@@ -220,4 +231,8 @@ fieldset li + li {
 		transform: rotate(-45deg);
 		width: 20rem;
 	}
+}
+
+.saved-searches > li {
+	margin-top: 1rem;
 }

--- a/src/js/pwa.js
+++ b/src/js/pwa.js
@@ -1,7 +1,32 @@
-/* global document, localStorage */
+/* global document, localStorage, window */
 const settings = document.querySelector('#settings');
 const lang = document.querySelector('#lang');
 const notice = document.querySelector('#notice');
+const searchForm = document.querySelector('#search-form');
+const searchField = document.querySelector('#search-field');
+const animalFilters = document.querySelector('.animals');
+const colorFilters = document.querySelector('.colors');
+const savedSearches = document.querySelector('#saved-searches');
+let db;
+
+function initDb() {
+	const request = window.indexedDB.open('search_db', 1);
+	request.addEventListener('error', () => {});
+
+	request.onupgradeneeded = event => {
+		const initialDb = event.target.result;
+		const objectStore = initialDb.createObjectStore('search_os', {keyPath: 'id', autoIncrement: true});
+
+		objectStore.createIndex('query', 'query', {unique: false});
+		objectStore.createIndex('animals', 'animals', {unique: false});
+		objectStore.createIndex('colors', 'colors', {unique: false});
+	};
+
+	request.onsuccess = () => {
+		db = request.result;
+		displayData();
+	};
+}
 
 function getLang() {
 	if (localStorage.getItem('lang')) {
@@ -13,7 +38,49 @@ function getLang() {
 	lang.hidden = false;
 }
 
+initDb();
 getLang();
+
+function addData(event) {
+	event.preventDefault();
+
+	const result = {
+		searchTerm: searchField.value,
+		animals: [],
+		colors: []
+	};
+	const animals = animalFilters.querySelectorAll('input:checked');
+	animals.forEach(animal => {
+		result.animals.push(animal.value);
+	});
+	const colors = colorFilters.querySelectorAll('input:checked');
+	colors.forEach(color => {
+		result.colors.push(color.value);
+	});
+
+	const transaction = db.transaction(['search_os'], 'readwrite');
+
+	const objectStore = transaction.objectStore('search_os');
+
+	const request = objectStore.add(result);
+	request.onsuccess = function () {
+		searchField.value = '';
+		animals.forEach(animal => {
+			animal.checked = false;
+		});
+		colors.forEach(color => {
+			color.checked = false;
+		});
+	};
+
+	transaction.oncomplete = function () {
+		displayData();
+	};
+
+	transaction.addEventListener('error', error => {
+		console.log(error);
+	});
+}
 
 settings.addEventListener('submit', event => {
 	event.preventDefault();
@@ -30,3 +97,76 @@ settings.addEventListener('submit', event => {
 		}, 1000);
 	}, 5000);
 });
+
+searchForm.addEventListener('submit', addData);
+
+function displayData() {
+	while (savedSearches.firstChild) {
+		savedSearches.removeChild(savedSearches.firstChild);
+	}
+
+	const objectStore = db.transaction('search_os').objectStore('search_os');
+	objectStore.openCursor().onsuccess = function (event) {
+		const cursor = event.target.result;
+		if (cursor) {
+			const listItem = document.createElement('li');
+			listItem.dataset.searchId = cursor.value.id;
+			const searchQuery = document.createElement('h3');
+			searchQuery.textContent = `Search Query: ${cursor.value.searchTerm}`;
+			listItem.append(searchQuery);
+			if (cursor.value.animals.length > 0) {
+				const animalHeader = document.createElement('p');
+				animalHeader.textContent = 'Animals:';
+				listItem.append(animalHeader);
+				const animalsList = document.createElement('ul');
+				listItem.append(animalsList);
+				cursor.value.animals.forEach(animal => {
+					const animalElement = document.createElement('li');
+					animalElement.textContent = animal;
+					animalsList.append(animalElement);
+				});
+			}
+
+			if (cursor.value.colors.length > 0) {
+				const colorHeader = document.createElement('p');
+				colorHeader.textContent = 'Colors:';
+				listItem.append(colorHeader);
+				const colorsList = document.createElement('ul');
+				cursor.value.colors.forEach(color => {
+					const colorElement = document.createElement('li');
+					colorElement.textContent = color;
+					colorsList.append(colorElement);
+				});
+				listItem.append(colorsList);
+			}
+
+			savedSearches.append(listItem);
+			const deleteBtn = document.createElement('button');
+			listItem.append(deleteBtn);
+			deleteBtn.textContent = 'Delete';
+			deleteBtn.addEventListener('click', deleteItem);
+			cursor.continue();
+		} else if (!savedSearches.firstChild) {
+			const listItem = document.createElement('li');
+			listItem.textContent = 'No searches saved.';
+			savedSearches.append(listItem);
+		}
+	};
+}
+
+function deleteItem(event) {
+	const searchId = Number(event.target.parentNode.getAttribute('data-search-id'));
+	const transaction = db.transaction(['search_os'], 'readwrite');
+	const objectStore = transaction.objectStore('search_os');
+	const request = objectStore.delete(searchId);
+	request.addEventListener('error', () => {});
+	transaction.oncomplete = function () {
+		event.target.parentNode.parentNode.removeChild(event.target.parentNode);
+
+		if (!savedSearches.firstChild) {
+			const listItem = document.createElement('li');
+			listItem.textContent = 'No searches saved.';
+			savedSearches.append(listItem);
+		}
+	};
+}

--- a/src/search.md
+++ b/src/search.md
@@ -1,0 +1,4 @@
+---
+layout: layouts/search.njk
+title: Search
+---

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,6 +1,6 @@
 /* global addEventListener, caches, clients, fetch, skipWaiting */
 
-const version = '20191004.6';
+const version = '20191004.8';
 const staticCacheName = version + 'staticFiles';
 
 addEventListener('install', installEvent => {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,6 +1,6 @@
 /* global addEventListener, caches, clients, fetch, skipWaiting */
 
-const version = '20191003.8';
+const version = '20191004.6';
 const staticCacheName = version + 'staticFiles';
 
 addEventListener('install', installEvent => {


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

On the search page, complex search queries can be saved and restored from IndexedDB.

## Steps to test

1. Visit the site at pwa-experiments.netlify.com.
2. Navigate to the Search page.
3. Select some filters and enter a search query, then submit the search.

**Expected behavior:** Your query and filters appears in the list of saved searches and persists on page reload. Saved searches can also be deleted.

## Additional information

- https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Client-side_web_APIs/Client-side_storage#Storing_complex_data_%E2%80%94_IndexedDB

## Related issues

- Resolves #4.
